### PR TITLE
feat(cra): support cra

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Add the preset to your [Jest config](https://jestjs.io/docs/en/configuration) (b
 }
 ```
 
+### Application create from CRA
+
+Add below line to your `setupTests.js`
+
+```
+import { configure } from "@spotify/polly-jest-presets/cjs/cra"
+configure({}) // Pass any valid polly config here
+```
+
 ### Getting Started
 
 To test it out, make a network request in one of your tests.
@@ -49,7 +58,7 @@ describe('a dummy test', () => {
 });
 ```
 
-First, you need to run the tests with the `POLLY_MODE` environment variable set to `record`. This will tell Polly that you intend for all of the requests to record in this test run. 
+First, you need to run the tests with the `POLLY_MODE` environment variable set to `record`. This will tell Polly that you intend for all of the requests to record in this test run.
 
 ```sh
 POLLY_MODE="record" jest
@@ -78,6 +87,8 @@ If you want to override Polly configuration, you can add configuration to `globa
   }
 }
 ```
+
+**For CRA**: pass config to `configure` function
 
 *See all of the valid Polly options [in the Polly documentation](https://netflix.github.io/pollyjs/#/configuration).*
 

--- a/src/__tests__/cra.test.ts
+++ b/src/__tests__/cra.test.ts
@@ -1,0 +1,18 @@
+import { Polly } from '@pollyjs/core';
+import {createPollyContext} from "../createPollyContext"
+import {configure} from '../cra';
+
+jest.mock("../createPollyContext")
+
+const createPollyContextMock = createPollyContext as typeof createPollyContext & {
+  mockReturnValueOnce(returnValue: object): void
+}
+
+describe('test configure for cra', () => {
+  it('creates polly context', () => {
+    createPollyContextMock.mockReturnValueOnce({polly: new Polly("FooBar")})
+    configure({})
+    expect(global.pollyContext.polly).toBeInstanceOf(Polly);
+  });
+
+});

--- a/src/__tests__/createPollyContext.test.ts
+++ b/src/__tests__/createPollyContext.test.ts
@@ -1,0 +1,15 @@
+import { setupPolly } from 'setup-polly-jest';
+
+import {createPollyContext, defaultConfig} from "../createPollyContext"
+
+jest.mock("setup-polly-jest")
+
+
+describe('test create polly context', () => {
+  it('creates polly context', () => {
+    createPollyContext({})
+    expect(setupPolly).toHaveBeenCalledWith(defaultConfig)
+
+  });
+
+});

--- a/src/cra.ts
+++ b/src/cra.ts
@@ -1,0 +1,13 @@
+import {PollyConfig} from "@pollyjs/core"
+import { createPollyContext } from './createPollyContext';
+
+export function configure(config:PollyConfig) {
+  const context = createPollyContext(config)
+  if (!global.pollyContext)
+  global.pollyContext = context;
+
+// Wait until all network requests are handled by Polly before ending each test.
+  global.afterEach(async () => {
+    await global.pollyContext.polly.flush();
+  });
+}

--- a/src/createPollyContext.ts
+++ b/src/createPollyContext.ts
@@ -1,0 +1,44 @@
+import { setupPolly } from 'setup-polly-jest';
+import { Polly, PollyConfig } from '@pollyjs/core';
+import NodeHttpAdapter from '@pollyjs/adapter-node-http';
+import FSPersister from '@pollyjs/persister-fs';
+import merge from 'lodash.merge';
+
+import { DEFAULT_RECORDING_DIR, DEFAULT_EXPIRATION_DAYS } from './constants';
+
+Polly.register(NodeHttpAdapter);
+Polly.register(FSPersister);
+
+const mode = process.env.POLLY_MODE || 'replay';
+
+// setup default config for Polly
+export const defaultConfig = {
+  adapters: ['node-http'],
+  persister: 'fs',
+  persisterOptions: {
+    keepUnusedRequests: false,
+    fs: {
+      recordingsDir: DEFAULT_RECORDING_DIR,
+    },
+  },
+  mode,
+  recordIfMissing: false,
+  recordFailedRequests: true,
+  expiryStrategy: process.env.CI ? 'error' : 'record',
+  expiresIn: `${DEFAULT_EXPIRATION_DAYS}d`,
+  // insulate the tests from differences in session data. we use order and
+  // url to match requests to one another, which we did previously with an
+  // internal fork of LinkedIn's Sepia VCR. This should be fine for deterministic
+  // requests, and you can circumvent non-deterministic stuff by manipulating
+  // things in the Polly Server: https://netflix.github.io/pollyjs/#/server/overview?id=overview
+  matchRequestsBy: {
+    headers: false,
+    body: false,
+  },
+};
+
+export function createPollyContext(config: PollyConfig) {
+// setup Polly instance and save it into global context
+  return setupPolly(merge({}, defaultConfig, config));
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,44 +1,7 @@
-import { setupPolly } from 'setup-polly-jest';
-import { Polly } from '@pollyjs/core';
-import NodeHttpAdapter from '@pollyjs/adapter-node-http';
-import FSPersister from '@pollyjs/persister-fs';
-import merge from 'lodash.merge';
-
-import { DEFAULT_RECORDING_DIR, DEFAULT_EXPIRATION_DAYS } from './constants';
-
-Polly.register(NodeHttpAdapter);
-Polly.register(FSPersister);
-
-const mode = process.env.POLLY_MODE || 'replay';
-
-// setup default config for Polly
-const defaultConfig = {
-  adapters: ['node-http'],
-  persister: 'fs',
-  persisterOptions: {
-    keepUnusedRequests: false,
-    fs: {
-      recordingsDir: DEFAULT_RECORDING_DIR,
-    },
-  },
-  mode,
-  recordIfMissing: false,
-  recordFailedRequests: true,
-  expiryStrategy: process.env.CI ? 'error' : 'record',
-  expiresIn: `${DEFAULT_EXPIRATION_DAYS}d`,
-  // insulate the tests from differences in session data. we use order and
-  // url to match requests to one another, which we did previously with an
-  // internal fork of LinkedIn's Sepia VCR. This should be fine for deterministic
-  // requests, and you can circumvent non-deterministic stuff by manipulating
-  // things in the Polly Server: https://netflix.github.io/pollyjs/#/server/overview?id=overview
-  matchRequestsBy: {
-    headers: false,
-    body: false,
-  },
-};
+import { createPollyContext } from './createPollyContext';
 
 // setup Polly instance and save it into global context
-const context = setupPolly(merge({}, defaultConfig, global.pollyConfig));
+const context = createPollyContext(global.pollyConfig || {});
 global.pollyContext = context;
 
 // Wait until all network requests are handled by Polly before ending each test.


### PR DESCRIPTION
The current setting is not configurable on CRA environment unless eject it.

1. Add setupFilesAfterEnv

It would get message:
```
We detected setupFilesAfterEnv in your package.json.

Remove it from Jest configuration, and put the initialization code in src/setupTests.js.
This file will be loaded automatically.
```

2. When add `global` to jest.config

It would get below message: 
```
These options in your package.json Jest configuration are not currently supported by Create React App:

  • globals

If you wish to override other Jest options, you need to eject from the default setup. You can do so by running npm run eject but remember that this is a one-way operation. You may also file an issue with Create React App to discuss supporting more options out of the box.
```